### PR TITLE
Make `GitBranch` public

### DIFF
--- a/Sources/Version-Control/Services/Models/GitBranch.swift
+++ b/Sources/Version-Control/Services/Models/GitBranch.swift
@@ -78,7 +78,7 @@ enum BranchType: Int {
     case remote = 1
 }
 
-struct GitBranch {
+public struct GitBranch {
     let name: String
     let upstream: String?
     let tip: IBranchTip


### PR DESCRIPTION
Required, as it's used in the editor codebase (needs to be renamed still from `Branch` to `GitBranch` there)